### PR TITLE
Syntax Colour Highlighting for Output HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,11 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet" />
     <link href="./css/style.css" rel="stylesheet" />
+
+    <!-- Import prism.js for html input syntax highlighting -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-html.min.js"></script>
 </head>
 
 <body>
@@ -70,8 +75,10 @@
                             </h5>
                         </div>
                         <div class="card-body">
-                            <textarea id="outputHtml" class="form-control" rows="20" readonly spellcheck="false"
-                                wrap="off"></textarea>
+                            <!-- Output displayed with syntax highlighting -->
+                            <pre style="height: 498px" class="form-control"><code id="outputHtml" class="language-html" rows="20" readonly spellcheck="false" wrap="off"></code></pre>
+                            <!-- <textarea id="outputHtml" class="form-control" rows="20" readonly spellcheck="false"
+                                wrap="off"></textarea> -->
                             <div class="d-flex gap-2 mt-2">
                                 <button class="btn btn-primary flex-grow-1" onclick="copyOutput()">
                                     <i class="fas fa-copy"></i> Copy Output

--- a/js/main.js
+++ b/js/main.js
@@ -368,7 +368,11 @@ function processHtml() {
     const options = getOptions();
   try {
     const modifiedHtml = modifyHtml(inputHtml, options);
-    document.getElementById('outputHtml').value = modifiedHtml;
+    const outputHtml = document.getElementById('outputHtml');
+    outputHtml.textContent = modifiedHtml;
+
+    // Syntax highlighting for the output html
+    Prism.highlightElement(outputHtml);
     updatePreview('outputPreview', modifiedHtml);
   } catch (error) {
     console.error('Error:', error);
@@ -379,8 +383,15 @@ function processHtml() {
 // --- Output Copy/Download ---
 function copyOutput() {
     const outputText = document.getElementById('outputHtml');
-    outputText.select();
+
+    // Temporarily create a textarea of the output text to copy it
+    const tempTextarea = document.createElement('textarea');
+    tempTextarea.value = outputText.textContent;
+    document.body.appendChild(tempTextarea);
+    tempTextarea.select();
     document.execCommand('copy');
+    document.body.removeChild(tempTextarea);
+
     const button = document.querySelector('.btn-primary');
     const originalText = button.innerHTML;
     button.innerHTML = '<i class="fas fa-check"></i> Copied!';
@@ -390,7 +401,7 @@ function copyOutput() {
 }
 
 function downloadOutput() {
-    const outputText = document.getElementById('outputHtml').value;
+    const outputText = document.getElementById('outputHtml').textContent;
     if (!outputText) {
         alert('No content to download!');
         return;


### PR DESCRIPTION
### Key Changes
- **Library added**: `prism.js`
- **Output HTML**: Replaced `<textarea>` with a `<pre><code>` html block to be compatible with `prism.js`.
- **ProcessHtml()**:  This is where the `Prism.highlightElement(outputHtml)` is called.
- **copyHtml()**: Updated for compatibility with `<pre><code>` rather than `<textarea>`.
- **downloadOutput()**: Getting the html using `.textContent` rather than `.value` to be compatible with `<pre><code>`.

### Result
<img width="1419" alt="image" src="https://github.com/user-attachments/assets/6ec1cf26-3419-4187-b4eb-21b815b597ca" />
